### PR TITLE
Fixed unlabeling bug

### DIFF
--- a/src/lib/issue-handler.js
+++ b/src/lib/issue-handler.js
@@ -45,7 +45,7 @@ export default class IssueHandler {
   }
 
   _removeIssueFromDatastore(internalIssueHash) {
-    // clean things up on Firebase
+    internalIssueHash.state = 'closed'; // ensure that this issue actually closes
     return this.dataStoreClient.removeIssue(internalIssueHash);
   }
 

--- a/src/repos.js
+++ b/src/repos.js
@@ -5,6 +5,7 @@ const standardLabels = [
 ];
 
 let repoList = [
+  'acorncom/ember-hitlist-tester',
   'ember-learn/ember-help-wanted',
   'ember-learn/ember-help-wanted-webhook',
   'emberjs/guides',

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -78,6 +78,13 @@ export default {
     return payload;
   },
 
+  payloadWithReqLabelButNoLabels: function(event) {
+    let payload = cloneObject(basePayload);
+    payload.action = event;
+    payload.issue.labels = [];
+    return payload;
+  },
+
   payloadWithoutReqLabel: function(event) {
     let payload = cloneObject(basePayload);
     let unrecognizedLabel = {
@@ -92,12 +99,26 @@ export default {
 
   issueForPayloadWithReqLabel: baseIssue,
 
-  issueForPayloadWithoutReqLabel: (function() {
+  issueForClosedPayloadWithReqLabel: (function() {
+    let issue = cloneObject(baseIssue);
+    issue.state = 'closed';
+    return issue;
+  })(),
+
+  issueForPayloadWithReqLabelButNoLabels: (function() {
+    let issue = cloneObject(baseIssue);
+    issue.labels = [];
+    issue.state = 'closed';
+    return issue;
+  })(),
+
+  issueForClosedPayloadWithoutReqLabel: (function() {
     let issue = cloneObject(baseIssue);
     issue.labels[0] = {
       "name": "i18n",
       "color": "84b6eb"
     };
+    issue.state = 'closed';
     return issue;
   })(),
 

--- a/tests/unit/issue-handler-test.js
+++ b/tests/unit/issue-handler-test.js
@@ -20,9 +20,12 @@ const repos ={
 
 const {
   payloadWithReqLabel,
+  payloadWithReqLabelButNoLabels,
   payloadWithoutReqLabel,
   issueForPayloadWithReqLabel,
-  issueForPayloadWithoutReqLabel
+  issueForPayloadWithReqLabelButNoLabels,
+  issueForClosedPayloadWithoutReqLabel,
+  issueForClosedPayloadWithReqLabel
 } = fixtures;
 
 describe(`Issue Handler Tests`, function() {
@@ -68,10 +71,19 @@ describe(`Issue Handler Tests`, function() {
   describe(`Unlabeling issues`, function() {
 
     it(`removes the issue from the store when it no longer has a valid label`, function(done) {
-      store.removeIssue.withArgs(issueForPayloadWithoutReqLabel).returns(Promise.resolve(true));
+      store.removeIssue.withArgs(issueForClosedPayloadWithoutReqLabel).returns(Promise.resolve(true));
       issueHandler.unlabel({ payload: payloadWithoutReqLabel('unlabeled')}).then(function() {
         assert.ok(true, 'Record is removed');
-        assert.ok(store.removeIssue.calledWith(issueForPayloadWithoutReqLabel));
+        assert.ok(store.removeIssue.calledWith(issueForClosedPayloadWithoutReqLabel));
+        done();
+      });
+    });
+
+    it(`removes the issue from the store when it no longer has any labels`, function(done) {
+      store.removeIssue.withArgs(issueForPayloadWithReqLabelButNoLabels).returns(Promise.resolve(true));
+      issueHandler.unlabel({ payload: payloadWithReqLabelButNoLabels('unlabeled')}).then(function() {
+        assert.ok(true, 'Record is removed');
+        assert.ok(store.removeIssue.calledWith(issueForPayloadWithReqLabelButNoLabels));
         done();
       });
     });
@@ -103,10 +115,10 @@ describe(`Issue Handler Tests`, function() {
   describe(`Closing issues`, function() {
 
     it(`removes the title on the client store`, function(done) {
-      store.removeIssue.withArgs(issueForPayloadWithReqLabel).returns(Promise.resolve(true));
+      store.removeIssue.withArgs(issueForClosedPayloadWithReqLabel).returns(Promise.resolve(true));
       issueHandler.close({payload: payloadWithReqLabel('closed')}).then(function() {
         assert.ok(true, 'Record was removed');
-        assert.ok(store.removeIssue.calledWith(issueForPayloadWithReqLabel));
+        assert.ok(store.removeIssue.calledWith(issueForClosedPayloadWithReqLabel));
         done();
       });
     });


### PR DESCRIPTION
When a previously labeled issue was unlabeled on a Github repo, the corresponding issue on Firebase would not be marked as closed (but was left open as we didn't enforce closing as part of closing an issue).

/cc @sivakumar-kailasam thoughts?
